### PR TITLE
feat(PROV-1377): add new bin ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@malga/card-validator",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A simple card validator",
   "author": "Malga <engineer@malga.io>",
   "contributors": [

--- a/src/card-validator/card-validator.spec.ts
+++ b/src/card-validator/card-validator.spec.ts
@@ -2946,7 +2946,10 @@ const cards = [
     cardNumber: '6376125509558696',
     issuer: 'Hiper',
   },
-
+  {
+    cardNumber: '6033422553845003',
+    issuer: 'Ticket',
+  }
 ]
 
 describe('card-validator', () => {

--- a/src/card-validator/card-validator.ts
+++ b/src/card-validator/card-validator.ts
@@ -1,15 +1,13 @@
 import * as valid from 'card-validator'
 
-
-
 valid.creditCardType.addCard({
   niceType: 'VR',
   type: 'vr',
   patterns: [
-    // VR Refeição:
+    // VR Refeição
     627416, 637202, 637200, 639834,
 
-    // VR Benefícios:
+    // VR Benefícios
     637036, 637201, 637200, 639833,
 
     // VR Auto
@@ -26,7 +24,7 @@ valid.creditCardType.addCard({
   },
 })
 
-// https://docs.adyen.com/development-resources/testing/test-other-payment-methods/#brazil-vouchers
+//@see: https://docs.adyen.com/development-resources/testing/test-other-payment-methods/#brazil-vouchers
 valid.creditCardType.addCard({
   niceType: 'Ticket',
   type: 'ticket',

--- a/src/card-validator/card-validator.ts
+++ b/src/card-validator/card-validator.ts
@@ -26,6 +26,19 @@ valid.creditCardType.addCard({
   },
 })
 
+// https://docs.adyen.com/development-resources/testing/test-other-payment-methods/#brazil-vouchers
+valid.creditCardType.addCard({
+  niceType: 'Ticket',
+  type: 'ticket',
+  patterns: [603342],
+  gaps: [],
+  lengths: [16],
+  code: {
+    name: 'CVV',
+    size: 3,
+  },
+})
+
 //@see: https://www.sodexobeneficios.com.br/estabelecimentos/treinamentos/como-aceitar-sodexo-na-sua-maquininha-ou-tef/configuracao-de-maquinas-tef.htm
 valid.creditCardType.addCard({
   niceType: 'Sodexo',

--- a/src/card-validator/card-validator.ts
+++ b/src/card-validator/card-validator.ts
@@ -1,9 +1,23 @@
 import * as valid from 'card-validator'
 
+
+
 valid.creditCardType.addCard({
   niceType: 'VR',
   type: 'vr',
-  patterns: [627416, 637036],
+  patterns: [
+    // VR Refeição:
+    627416, 637202, 637200, 639834,
+
+    // VR Benefícios:
+    637036, 637201, 637200, 639833,
+
+    // VR Auto
+    637037, 637200,
+
+    // VR Cultura
+    636350, 637200
+  ],
   gaps: [],
   lengths: [16],
   code: {


### PR DESCRIPTION
## Motivation (prefer a non-technical explanation)

We need to include new ranges of supported card types

## Proposed solution (including technical details and their motivations)

- Inclusion of the bin range returned by VR
- Inclusion of a Ticket bin that is known by Malga. Adyen also recognizes the bin as a ticket so the bin is correct
  - https://docs.adyen.com/development-resources/testing/test-other-payment-methods/#brazil-vouchers

## Observations (optional - any additional information you deem important)

We do not include VR tests as we do not have a list of cards to be tested

## Issues (optional - resolution of any issue with this PR)

https://malga.atlassian.net/browse/PROV-1377 (internal request)
