### PR TITLE
feat: create a funtion to return a mask for card number

### DIFF
--- a/src/card-validator/card-validator.spec.ts
+++ b/src/card-validator/card-validator.spec.ts
@@ -2975,9 +2975,9 @@ describe('card-validator', () => {
     cards.forEach((card) => {
       const result = valid.number(card.cardNumber)
 
-      if (!result.card?.type) return
+      expect(result.card).toBeDefined()
 
-      const mask = maskCardNumber(result.card?.type)
+      const mask = maskCardNumber(result.card?.type, '%')
 
       const spaceIndexes = result.card?.gaps.map((gap, i) => gap + i) ?? []
 
@@ -2985,11 +2985,9 @@ describe('card-validator', () => {
         if (spaceIndexes.includes(i)) {
           expect(char).toBe(' ')
         } else {
-          expect(char).toBe('0')
+          expect(char).toBe('%')
         }
       })
-
-
     })
   })
 })

--- a/src/card-validator/card-validator.ts
+++ b/src/card-validator/card-validator.ts
@@ -72,7 +72,10 @@ valid.creditCardType.addCard({
   },
 })
 
-function maskCardNumber(type: string) {
+function maskCardNumber(type?: string, maskDigit = '0') {
+  if (!type) throw new Error('Invalid card type')
+
+
   const infos = valid.creditCardType.getTypeInfo(type)
 
   const biggestCardNumber = Math.max(...infos.lengths)
@@ -82,7 +85,7 @@ function maskCardNumber(type: string) {
     if (infos.gaps.includes(i)) {
       mask += ' '
     }
-    mask += '0'
+    mask += maskDigit
   }
 
   return mask


### PR DESCRIPTION
## Motivation (prefer a non-technical explanation)

Na aplicação de hosted-fields, tinhamos definido apenas uma máscara genérica para todos os cartões. Com o objeto de melhor essa máscara no `hf` e no `malga-checkout`, em que ambos usam a `card-validator`, criei uma função para isso: a `maskCardNumber`.

## Proposed solution (including technical details and their motivations)

Basicamente, ela recebe o [type do card](https://github.com/braintree/credit-card-type/blob/main/src/lib/card-types.ts) e aciona a função de getInfo que dentre outras coisas retorna 2 informações principais: `lengths` e `gaps`.

Lengths são os tamanhos possíveis que aquele type pode ter de digitos de cartão (ex: unionpay pode ter cartões com `lengths: [16, 17, 18, 19] dígitos`) e gaps é um array que define onde fica o espaço em branco da máscara (`ex: [4, 8, 12] ele vai ter espaços na posição 4, 8 e 12, ex: 0000 0000 0000 0000`). 

O que a função faz é simples, escolhe o maior tamanho do array de lengths, no caso do exemplo dado a cima seria o 19, e faz um for nessas posições (0 - 19), colocando 0 onde não for a posição do array de gaps e ' '  quando for. 

## Observations (optional - any additional information you deem important)

Isso vai ser muito útil, por quê?

após um tempinho pensando na melhor forma de fazer isso que pudesse ser aproveitado em mais de uma aplicação malga, vi que o type é retornado assim que o usuário digita o BIN (que pode ser os 4 ou 6 primeiros números do cartão) e nesse momento podemos chamar a função criada com o type e já aplicar a máscara, seja no onChange (caso do checkout), seja no updateOptions do IMask usado no hosted-fields.

- Criei um teste unitário pra essa função também. 
