### PR TITLE
refactor: change the cardValidator export

### DIFF
--- a/src/card-validator/index.ts
+++ b/src/card-validator/index.ts
@@ -1,3 +1,3 @@
-import cardValidator from './card-validator'
+import * as cardValidator from './card-validator'
 
 export default cardValidator


### PR DESCRIPTION
Como agora temos dois retornos: valid e maskCardNumber, precisei exportar tudo (*) e usei um alias pra ser cardValidator. Assim, seu uso será cardValidator.valid ou cardValdiator.maskCardNumber.